### PR TITLE
feat: enable vite module federation shell and remotes

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,0 +1,21 @@
+module.exports = {
+  root: true,
+  env: {
+    browser: true,
+    es2021: true,
+    node: true,
+  },
+  extends: [
+    'eslint:recommended',
+    'plugin:vue/vue3-essential',
+    'plugin:@typescript-eslint/recommended',
+    'prettier'
+  ],
+  parser: 'vue-eslint-parser',
+  parserOptions: {
+    parser: '@typescript-eslint/parser',
+    ecmaVersion: 'latest',
+    sourceType: 'module'
+  },
+  rules: {}
+}

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+npx --no-install commitlint --edit "$1"

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+pnpm lint-staged

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,6 @@
+{
+  "semi": false,
+  "singleQuote": true,
+  "tabWidth": 2,
+  "trailingComma": "none"
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
-# Test-proj
+# Enterprise Micro-Frontend Portal
+
+This repository hosts a micro-frontend portal built with Vue 3, Vite, and pnpm workspaces. It showcases a shell application and several core packages including UI kit, event bus, and authentication.
+
+## Workspace Structure
+- `packages/core/*`: Shared core libraries
+- `packages/shell`: Shell host application
+- `packages/micro-apps/*`: Example micro-frontend applications
+
+## Development
+```bash
+pnpm install
+pnpm dev
+```

--- a/package.json
+++ b/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@enterprise/portal",
+  "version": "1.0.0",
+  "private": true,
+  "engines": {
+    "node": ">=18.0.0",
+    "pnpm": ">=8.0.0"
+  },
+  "scripts": {
+    "dev": "turbo run dev --parallel",
+    "build": "turbo run build",
+    "lint": "turbo run lint",
+    "type-check": "turbo run type-check",
+    "preview": "turbo run preview",
+    "clean": "turbo run clean && rm -rf node_modules",
+    "prepare": "husky install"
+  },
+  "devDependencies": {
+    "turbo": "^1.13.0",
+    "@types/node": "^20.11.0",
+    "typescript": "^5.4.0",
+    "eslint": "^8.57.0",
+    "prettier": "^3.2.0",
+    "husky": "^9.0.0",
+    "lint-staged": "^15.2.0",
+    "@commitlint/cli": "^18.6.0",
+    "@commitlint/config-conventional": "^18.6.0"
+  },
+  "lint-staged": {
+    "*.{ts,tsx,vue}": ["eslint --fix", "prettier --write"],
+    "*.{json,md,yml}": ["prettier --write"]
+  }
+}

--- a/packages/core/api-client/package.json
+++ b/packages/core/api-client/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@enterprise/api-client",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts"
+}

--- a/packages/core/api-client/src/index.ts
+++ b/packages/core/api-client/src/index.ts
@@ -1,0 +1,4 @@
+// Placeholder for API client implementation
+export function createApiClient() {
+  return {}
+}

--- a/packages/core/auth/package.json
+++ b/packages/core/auth/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@enterprise/auth",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "dependencies": {
+    "pinia": "^2.1.0",
+    "jwt-decode": "^4.0.0"
+  }
+}

--- a/packages/core/auth/src/index.ts
+++ b/packages/core/auth/src/index.ts
@@ -1,0 +1,278 @@
+import { ref, computed, readonly } from 'vue'
+import { defineStore } from 'pinia'
+import jwt_decode from 'jwt-decode'
+
+export interface User {
+  id: string
+  email: string
+  firstName: string
+  lastName: string
+  nationalCode: string
+  mobile: string
+  roles: string[]
+  permissions: string[]
+  avatar?: string
+}
+
+export interface AuthTokens {
+  accessToken: string
+  refreshToken: string
+  expiresIn: number
+  tokenType: string
+}
+
+export interface LoginCredentials {
+  username: string
+  password: string
+  captcha?: string
+}
+
+// Auth store using Pinia
+export const useAuthStore = defineStore('auth', () => {
+  // State
+  const user = ref<User | null>(null)
+  const tokens = ref<AuthTokens | null>(null)
+  const isLoading = ref(false)
+  const error = ref<string | null>(null)
+  
+  // Getters
+  const isAuthenticated = computed(() => !!tokens.value?.accessToken)
+  const currentUser = computed(() => readonly(user.value))
+  const userPermissions = computed(() => user.value?.permissions || [])
+  const userRoles = computed(() => user.value?.roles || [])
+  
+  // Actions
+  async function login(credentials: LoginCredentials): Promise<void> {
+    isLoading.value = true
+    error.value = null
+    
+    try {
+      const response = await fetch('/api/auth/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(credentials)
+      })
+      
+      if (!response.ok) {
+        throw new Error('Authentication failed')
+      }
+      
+      const data = await response.json()
+      tokens.value = data.tokens
+      user.value = data.user
+      
+      // Store tokens
+      localStorage.setItem('access_token', data.tokens.accessToken)
+      localStorage.setItem('refresh_token', data.tokens.refreshToken)
+      
+      // Setup token refresh
+      scheduleTokenRefresh()
+      
+      // Emit login event
+      window.dispatchEvent(new CustomEvent('auth:login', { detail: user.value }))
+      
+    } catch (err) {
+      error.value = err instanceof Error ? err.message : 'Login failed'
+      throw err
+    } finally {
+      isLoading.value = false
+    }
+  }
+  
+  async function logout(): Promise<void> {
+    try {
+      await fetch('/api/auth/logout', {
+        method: 'POST',
+        headers: {
+          'Authorization': `Bearer ${tokens.value?.accessToken}`
+        }
+      })
+    } catch (err) {
+      console.error('Logout error:', err)
+    } finally {
+      // Clear local state
+      user.value = null
+      tokens.value = null
+      localStorage.removeItem('access_token')
+      localStorage.removeItem('refresh_token')
+      
+      // Emit logout event
+      window.dispatchEvent(new CustomEvent('auth:logout'))
+      
+      // Redirect to login
+      window.location.href = '/login'
+    }
+  }
+  
+  async function refreshAccessToken(): Promise<void> {
+    const refreshToken = localStorage.getItem('refresh_token')
+    
+    if (!refreshToken) {
+      throw new Error('No refresh token available')
+    }
+    
+    try {
+      const response = await fetch('/api/auth/refresh', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ refreshToken })
+      })
+      
+      if (!response.ok) {
+        throw new Error('Token refresh failed')
+      }
+      
+      const data = await response.json()
+      tokens.value = data.tokens
+      localStorage.setItem('access_token', data.tokens.accessToken)
+      
+      scheduleTokenRefresh()
+    } catch (err) {
+      // Refresh failed, force re-login
+      await logout()
+      throw err
+    }
+  }
+  
+  async function checkAuth(): Promise<void> {
+    const accessToken = localStorage.getItem('access_token')
+    
+    if (!accessToken) {
+      return
+    }
+    
+    try {
+      // Validate token with backend
+      const response = await fetch('/api/auth/me', {
+        headers: {
+          'Authorization': `Bearer ${accessToken}`
+        }
+      })
+      
+      if (response.ok) {
+        const data = await response.json()
+        user.value = data.user
+        tokens.value = {
+          accessToken,
+          refreshToken: localStorage.getItem('refresh_token') || '',
+          expiresIn: 3600,
+          tokenType: 'Bearer'
+        }
+        scheduleTokenRefresh()
+      } else {
+        await refreshAccessToken()
+      }
+    } catch (err) {
+      console.error('Auth check failed:', err)
+    }
+  }
+  
+  function hasPermission(permission: string): boolean {
+    return userPermissions.value.includes(permission)
+  }
+  
+  function hasAnyPermission(permissions: string[]): boolean {
+    return permissions.some(p => userPermissions.value.includes(p))
+  }
+  
+  function hasAllPermissions(permissions: string[]): boolean {
+    return permissions.every(p => userPermissions.value.includes(p))
+  }
+  
+  function hasRole(role: string): boolean {
+    return userRoles.value.includes(role)
+  }
+  
+  function hasAnyRole(roles: string[]): boolean {
+    return roles.some(r => userRoles.value.includes(r))
+  }
+  
+  let refreshTimer: NodeJS.Timeout | null = null
+  
+  function scheduleTokenRefresh(): void {
+    if (refreshTimer) {
+      clearTimeout(refreshTimer)
+    }
+    
+    if (!tokens.value?.accessToken) {
+      return
+    }
+    
+    try {
+      const decoded = jwt_decode<{ exp: number }>(tokens.value.accessToken)
+      const expiresIn = decoded.exp * 1000 - Date.now()
+      const refreshIn = Math.max(0, expiresIn - 60000) // Refresh 1 minute before expiry
+      
+      refreshTimer = setTimeout(() => {
+        refreshAccessToken().catch(console.error)
+      }, refreshIn)
+    } catch (err) {
+      console.error('Failed to schedule token refresh:', err)
+    }
+  }
+  
+  // Initialize
+  checkAuth()
+  
+  return {
+    // State
+    user: readonly(user),
+    isLoading: readonly(isLoading),
+    error: readonly(error),
+    
+    // Getters
+    isAuthenticated,
+    currentUser,
+    userPermissions,
+    userRoles,
+    
+    // Actions
+    login,
+    logout,
+    refreshAccessToken,
+    checkAuth,
+    hasPermission,
+    hasAnyPermission,
+    hasAllPermissions,
+    hasRole,
+    hasAnyRole
+  }
+})
+
+// Route guard composable
+export function useAuthGuard() {
+  const auth = useAuthStore()
+  
+  return {
+    requireAuth: (to: any, from: any, next: any) => {
+      if (auth.isAuthenticated) {
+        next()
+      } else {
+        next({
+          path: '/login',
+          query: { redirect: to.fullPath }
+        })
+      }
+    },
+    
+    requirePermission: (permission: string) => {
+      return (to: any, from: any, next: any) => {
+        if (auth.hasPermission(permission)) {
+          next()
+        } else {
+          next({ path: '/403' })
+        }
+      }
+    },
+    
+    requireRole: (role: string) => {
+      return (to: any, from: any, next: any) => {
+        if (auth.hasRole(role)) {
+          next()
+        } else {
+          next({ path: '/403' })
+        }
+      }
+    }
+  }
+}

--- a/packages/core/event-bus/package.json
+++ b/packages/core/event-bus/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@enterprise/event-bus",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "dependencies": {
+    "events": "^3.3.0",
+    "zod": "^3.22.0"
+  }
+}

--- a/packages/core/event-bus/src/index.ts
+++ b/packages/core/event-bus/src/index.ts
@@ -1,0 +1,210 @@
+import { EventEmitter } from 'events'
+import { z } from 'zod'
+
+// Define event schemas with Zod for type safety
+export const EventSchemas = {
+  USER_LOGIN: z.object({
+    userId: z.string(),
+    email: z.string().email(),
+    timestamp: z.number(),
+    sessionId: z.string()
+  }),
+  
+  USER_LOGOUT: z.object({
+    userId: z.string(),
+    timestamp: z.number()
+  }),
+  
+  DATA_UPDATE: z.object({
+    entity: z.string(),
+    id: z.string(),
+    changes: z.record(z.unknown()),
+    source: z.string(),
+    timestamp: z.number()
+  }),
+  
+  NAVIGATION: z.object({
+    from: z.string(),
+    to: z.string(),
+    params: z.record(z.string()).optional(),
+    query: z.record(z.string()).optional()
+  }),
+  
+  APP_LOADED: z.object({
+    appId: z.string(),
+    version: z.string(),
+    loadTime: z.number()
+  }),
+  
+  ERROR_OCCURRED: z.object({
+    appId: z.string(),
+    error: z.string(),
+    stack: z.string().optional(),
+    timestamp: z.number()
+  })
+}
+
+// Generate TypeScript types from schemas
+export type EventMap = {
+  [K in keyof typeof EventSchemas]: z.infer<typeof EventSchemas[K]>
+}
+
+export type EventName = keyof EventMap
+
+class TypedEventBus extends EventEmitter {
+  private static instance: TypedEventBus
+  private messageQueue: Array<{
+    event: string
+    data: any
+    timestamp: number
+  }> = []
+  
+  private constructor() {
+    super()
+    this.setupGlobalListener()
+  }
+  
+  static getInstance(): TypedEventBus {
+    if (!TypedEventBus.instance) {
+      TypedEventBus.instance = new TypedEventBus()
+    }
+    return TypedEventBus.instance
+  }
+  
+  private setupGlobalListener() {
+    window.addEventListener('message', (event) => {
+      if (event.data?.type === 'MICRO_APP_EVENT') {
+        const { event: eventName, data, source } = event.data
+        
+        // Don't process our own events
+        if (source !== this.getCurrentAppId()) {
+          this.handleRemoteEvent(eventName, data)
+        }
+      }
+    })
+  }
+  
+  private handleRemoteEvent(eventName: string, data: any) {
+    // Validate and re-emit locally
+    try {
+      const schema = EventSchemas[eventName as EventName]
+      if (schema) {
+        const validated = schema.parse(data)
+        super.emit(eventName, validated)
+      }
+    } catch (error) {
+      console.error(`Invalid event data for ${eventName}:`, error)
+    }
+  }
+  
+  emit<K extends EventName>(event: K, data: EventMap[K]): boolean {
+    // Validate data
+    const schema = EventSchemas[event]
+    const validated = schema.parse(data)
+    
+    // Log in development
+    if (import.meta.env.DEV) {
+      console.log(`[EventBus] ${event}:`, validated)
+    }
+    
+    // Queue for potential replay
+    this.messageQueue.push({
+      event,
+      data: validated,
+      timestamp: Date.now()
+    })
+    
+    // Trim queue if too large
+    if (this.messageQueue.length > 100) {
+      this.messageQueue = this.messageQueue.slice(-50)
+    }
+    
+    // Broadcast to other micro-apps
+    window.postMessage({
+      type: 'MICRO_APP_EVENT',
+      event,
+      data: validated,
+      source: this.getCurrentAppId()
+    }, '*')
+    
+    return super.emit(event, validated)
+  }
+  
+  on<K extends EventName>(
+    event: K,
+    listener: (data: EventMap[K]) => void
+  ): this {
+    return super.on(event, listener)
+  }
+  
+  once<K extends EventName>(
+    event: K,
+    listener: (data: EventMap[K]) => void
+  ): this {
+    return super.once(event, listener)
+  }
+  
+  off<K extends EventName>(
+    event: K,
+    listener: (data: EventMap[K]) => void
+  ): this {
+    return super.off(event, listener)
+  }
+  
+  // Request-Response pattern for inter-app communication
+  async request<K extends EventName, R = any>(
+    event: K,
+    data: EventMap[K],
+    timeout = 5000
+  ): Promise<R> {
+    const requestId = crypto.randomUUID()
+    const responseEvent = `${event}:response:${requestId}` as const
+    
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.off(responseEvent as any, responseHandler)
+        reject(new Error(`Request timeout for ${event}`))
+      }, timeout)
+      
+      const responseHandler = (response: R) => {
+        clearTimeout(timer)
+        resolve(response)
+      }
+      
+      this.once(responseEvent as any, responseHandler)
+      this.emit(event, {
+        ...data,
+        __requestId: requestId,
+        __responseEvent: responseEvent
+      } as any)
+    })
+  }
+  
+  private getCurrentAppId(): string {
+    return (window as any).__MICRO_APP_ID__ || 'shell'
+  }
+  
+  // Replay queued messages (useful after reconnection)
+  replayQueue(filter?: (item: typeof this.messageQueue[0]) => boolean): void {
+    const items = filter ? this.messageQueue.filter(filter) : this.messageQueue
+    
+    items.forEach(({ event, data }) => {
+      super.emit(event, data)
+    })
+  }
+  
+  clearQueue(): void {
+    this.messageQueue = []
+  }
+}
+
+// Export singleton instance
+export const eventBus = TypedEventBus.getInstance()
+
+// Vue plugin
+export const EventBusPlugin = {
+  install(app: any) {
+    app.config.globalProperties.$eventBus = eventBus
+    app.provide('eventBus', eventBus)
+  }
+}

--- a/packages/core/shared-utils/package.json
+++ b/packages/core/shared-utils/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@enterprise/shared-utils",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts"
+}

--- a/packages/core/shared-utils/src/index.ts
+++ b/packages/core/shared-utils/src/index.ts
@@ -1,0 +1,2 @@
+// Shared utility functions
+export const noop = () => {}

--- a/packages/core/types/package.json
+++ b/packages/core/types/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@enterprise/types",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts"
+}

--- a/packages/core/types/src/index.ts
+++ b/packages/core/types/src/index.ts
@@ -1,0 +1,5 @@
+// Shared TypeScript types
+export interface Pagination {
+  page: number
+  pageSize: number
+}

--- a/packages/core/ui-kit/package.json
+++ b/packages/core/ui-kit/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@enterprise/ui-kit",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "./dist/ui-kit.js",
+  "module": "./dist/ui-kit.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/ui-kit.js",
+      "require": "./dist/ui-kit.umd.cjs",
+      "types": "./dist/index.d.ts"
+    },
+    "./styles": "./dist/style.css"
+  },
+  "scripts": {
+    "dev": "vite build --watch",
+    "build": "vue-tsc && vite build",
+    "type-check": "vue-tsc --noEmit"
+  },
+  "peerDependencies": {
+    "vue": "^3.4.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-vue": "^5.0.0",
+    "vite": "^5.1.0",
+    "vue-tsc": "^1.8.0",
+    "sass": "^1.70.0"
+  }
+}

--- a/packages/core/ui-kit/src/components/BaseButton.vue
+++ b/packages/core/ui-kit/src/components/BaseButton.vue
@@ -1,0 +1,74 @@
+<template>
+  <button
+    :type="type"
+    :class="buttonClasses"
+    :disabled="disabled || loading"
+    @click="handleClick"
+  >
+    <span v-if="loading" class="btn-loader">
+      <svg class="animate-spin h-4 w-4" viewBox="0 0 24 24">
+        <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" fill="none" />
+        <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+      </svg>
+    </span>
+    <span :class="{ 'opacity-0': loading }">
+      <slot />
+    </span>
+  </button>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+
+export interface ButtonProps {
+  variant?: 'primary' | 'secondary' | 'danger' | 'ghost'
+  size?: 'sm' | 'md' | 'lg'
+  type?: 'button' | 'submit' | 'reset'
+  disabled?: boolean
+  loading?: boolean
+  fullWidth?: boolean
+}
+
+const props = withDefaults(defineProps<ButtonProps>(), {
+  variant: 'primary',
+  size: 'md',
+  type: 'button',
+  disabled: false,
+  loading: false,
+  fullWidth: false
+})
+
+const emit = defineEmits<{
+  click: [event: MouseEvent]
+}>()
+
+const buttonClasses = computed(() => {
+  const base = 'inline-flex items-center justify-center font-medium transition-all duration-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed relative'
+  
+  const variants = {
+    primary: 'bg-primary-600 text-white hover:bg-primary-700 focus:ring-primary-500',
+    secondary: 'bg-gray-200 text-gray-900 hover:bg-gray-300 focus:ring-gray-500',
+    danger: 'bg-red-600 text-white hover:bg-red-700 focus:ring-red-500',
+    ghost: 'bg-transparent text-gray-700 hover:bg-gray-100 focus:ring-gray-500'
+  }
+  
+  const sizes = {
+    sm: 'px-3 py-1.5 text-sm',
+    md: 'px-4 py-2 text-base',
+    lg: 'px-6 py-3 text-lg'
+  }
+  
+  return [
+    base,
+    variants[props.variant],
+    sizes[props.size],
+    props.fullWidth && 'w-full'
+  ].filter(Boolean).join(' ')
+})
+
+const handleClick = (event: MouseEvent) => {
+  if (!props.disabled && !props.loading) {
+    emit('click', event)
+  }
+}
+</script>

--- a/packages/core/ui-kit/src/components/BaseCard.vue
+++ b/packages/core/ui-kit/src/components/BaseCard.vue
@@ -1,0 +1,9 @@
+<template>
+  <div class="bg-white shadow-sm rounded p-4">
+    <slot />
+  </div>
+</template>
+
+<script setup lang="ts">
+// simple card component
+</script>

--- a/packages/core/ui-kit/src/components/BaseInput.vue
+++ b/packages/core/ui-kit/src/components/BaseInput.vue
@@ -1,0 +1,29 @@
+<template>
+  <input
+    v-bind="attrs"
+    :class="['border rounded px-3 py-2', fullWidth && 'w-full']"
+    :value="modelValue"
+    @input="onInput"
+  />
+</template>
+
+<script setup lang="ts">
+import { useAttrs } from 'vue'
+
+export interface InputProps {
+  modelValue?: string | number
+  fullWidth?: boolean
+}
+
+const props = defineProps<InputProps>()
+const emit = defineEmits(['update:modelValue'])
+const attrs = useAttrs()
+
+const onInput = (e: Event) => {
+  const target = e.target as HTMLInputElement
+  emit('update:modelValue', target.value)
+}
+
+const fullWidth = props.fullWidth
+const modelValue = props.modelValue
+</script>

--- a/packages/core/ui-kit/src/components/BaseLoading.vue
+++ b/packages/core/ui-kit/src/components/BaseLoading.vue
@@ -1,0 +1,12 @@
+<template>
+  <div class="flex items-center justify-center p-4">
+    <svg class="animate-spin h-6 w-6 text-primary-600" viewBox="0 0 24 24">
+      <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" fill="none" />
+      <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+    </svg>
+  </div>
+</template>
+
+<script setup lang="ts">
+// loading indicator
+</script>

--- a/packages/core/ui-kit/src/components/BaseModal.vue
+++ b/packages/core/ui-kit/src/components/BaseModal.vue
@@ -1,0 +1,24 @@
+<template>
+  <div v-if="visible" class="fixed inset-0 flex items-center justify-center bg-black/50">
+    <div class="bg-white p-4 rounded shadow-lg">
+      <slot />
+      <button class="mt-2" @click="close">Close</button>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, watch } from 'vue'
+
+export interface ModalProps {
+  modelValue: boolean
+}
+
+const props = defineProps<ModalProps>()
+const emit = defineEmits(['update:modelValue'])
+
+const visible = ref(props.modelValue)
+watch(() => props.modelValue, v => (visible.value = v))
+
+const close = () => emit('update:modelValue', false)
+</script>

--- a/packages/core/ui-kit/src/components/BaseTable.vue
+++ b/packages/core/ui-kit/src/components/BaseTable.vue
@@ -1,0 +1,9 @@
+<template>
+  <table class="min-w-full divide-y divide-gray-200">
+    <slot />
+  </table>
+</template>
+
+<script setup lang="ts">
+// simple table wrapper
+</script>

--- a/packages/core/ui-kit/src/components/BaseToast.vue
+++ b/packages/core/ui-kit/src/components/BaseToast.vue
@@ -1,0 +1,11 @@
+<template>
+  <div v-if="visible" class="fixed top-4 right-4 bg-gray-800 text-white px-4 py-2 rounded shadow">
+    <slot />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+
+const visible = ref(true)
+</script>

--- a/packages/core/ui-kit/src/composables/useModal.ts
+++ b/packages/core/ui-kit/src/composables/useModal.ts
@@ -1,0 +1,8 @@
+import { ref } from 'vue'
+
+export function useModal() {
+  const isOpen = ref(false)
+  const open = () => (isOpen.value = true)
+  const close = () => (isOpen.value = false)
+  return { isOpen, open, close }
+}

--- a/packages/core/ui-kit/src/composables/useTheme.ts
+++ b/packages/core/ui-kit/src/composables/useTheme.ts
@@ -1,0 +1,14 @@
+import { ref } from 'vue'
+
+type Theme = 'light' | 'dark'
+
+export function useTheme() {
+  const theme = ref<Theme>('light')
+
+  function setTheme(t: Theme) {
+    theme.value = t
+    document.documentElement.setAttribute('data-theme', t)
+  }
+
+  return { theme, setTheme }
+}

--- a/packages/core/ui-kit/src/composables/useToast.ts
+++ b/packages/core/ui-kit/src/composables/useToast.ts
@@ -1,0 +1,12 @@
+import { ref } from 'vue'
+
+export function useToast() {
+  const message = ref<string | null>(null)
+
+  function show(msg: string, timeout = 3000) {
+    message.value = msg
+    setTimeout(() => (message.value = null), timeout)
+  }
+
+  return { message, show }
+}

--- a/packages/core/ui-kit/src/index.ts
+++ b/packages/core/ui-kit/src/index.ts
@@ -1,0 +1,21 @@
+// Components
+export { default as BaseButton } from './components/BaseButton.vue'
+export { default as BaseInput } from './components/BaseInput.vue'
+export { default as BaseModal } from './components/BaseModal.vue'
+export { default as BaseCard } from './components/BaseCard.vue'
+export { default as BaseTable } from './components/BaseTable.vue'
+export { default as BaseToast } from './components/BaseToast.vue'
+export { default as BaseLoading } from './components/BaseLoading.vue'
+
+// Composables
+export { useToast } from './composables/useToast'
+export { useModal } from './composables/useModal'
+export { useTheme } from './composables/useTheme'
+
+// Types
+export type { ButtonProps } from './components/BaseButton.vue'
+export type { InputProps } from './components/BaseInput.vue'
+export type { ModalProps } from './components/BaseModal.vue'
+
+// Import styles in your app
+import './tokens/design-tokens.css'

--- a/packages/core/ui-kit/src/tokens/design-tokens.css
+++ b/packages/core/ui-kit/src/tokens/design-tokens.css
@@ -1,0 +1,58 @@
+:root {
+  /* Colors - Support both light and dark themes */
+  --color-primary-50: #f0f9ff;
+  --color-primary-100: #e0f2fe;
+  --color-primary-200: #bae6fd;
+  --color-primary-300: #7dd3fc;
+  --color-primary-400: #38bdf8;
+  --color-primary-500: #0ea5e9;
+  --color-primary-600: #0284c7;
+  --color-primary-700: #0369a1;
+  --color-primary-800: #075985;
+  --color-primary-900: #0c4a6e;
+
+  /* Spacing */
+  --space-xs: 0.25rem;
+  --space-sm: 0.5rem;
+  --space-md: 1rem;
+  --space-lg: 1.5rem;
+  --space-xl: 2rem;
+  --space-2xl: 3rem;
+
+  /* Typography */
+  --font-family: 'IRANSansX', system-ui, -apple-system, sans-serif;
+  --font-size-xs: 0.75rem;
+  --font-size-sm: 0.875rem;
+  --font-size-base: 1rem;
+  --font-size-lg: 1.125rem;
+  --font-size-xl: 1.25rem;
+  --font-size-2xl: 1.5rem;
+
+  /* Shadows */
+  --shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.05);
+  --shadow-md: 0 4px 6px -1px rgb(0 0 0 / 0.1);
+  --shadow-lg: 0 10px 15px -3px rgb(0 0 0 / 0.1);
+
+  /* Border Radius */
+  --radius-sm: 0.25rem;
+  --radius-md: 0.375rem;
+  --radius-lg: 0.5rem;
+  --radius-xl: 0.75rem;
+  --radius-full: 9999px;
+
+  /* Transitions */
+  --transition-fast: 150ms ease-in-out;
+  --transition-base: 250ms ease-in-out;
+  --transition-slow: 350ms ease-in-out;
+}
+
+[data-theme="dark"] {
+  --color-primary-50: #0c4a6e;
+  --color-primary-900: #f0f9ff;
+  /* Add more dark theme overrides */
+}
+
+/* RTL Support */
+[dir="rtl"] {
+  --font-family: 'IRANSansX', 'Vazirmatn', system-ui, sans-serif;
+}

--- a/packages/micro-apps/customer-management/index.html
+++ b/packages/micro-apps/customer-management/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>MFE</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/packages/micro-apps/customer-management/package.json
+++ b/packages/micro-apps/customer-management/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@enterprise/customer-management",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vue-tsc && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "vue": "^3.4.0",
+    "vue-router": "^4.2.0",
+    "pinia": "^2.1.0",
+    "@enterprise/ui-kit": "workspace:*",
+    "@enterprise/auth": "workspace:*",
+    "@enterprise/event-bus": "workspace:*"
+  },
+    "devDependencies": {
+    "@vitejs/plugin-vue": "^5.0.0",
+    "@originjs/vite-plugin-federation": "^1.3.0",
+    "vite": "^5.1.0",
+    "vue-tsc": "^1.8.0",
+    "sass": "^1.70.0",
+    "tailwindcss": "^3.4.0",
+    "autoprefixer": "^10.4.0",
+    "postcss": "^8.4.0"
+    }
+}

--- a/packages/micro-apps/customer-management/postcss.config.js
+++ b/packages/micro-apps/customer-management/postcss.config.js
@@ -1,0 +1,1 @@
+export default { plugins: { tailwindcss: {}, autoprefixer: {} } }

--- a/packages/micro-apps/customer-management/src/App.vue
+++ b/packages/micro-apps/customer-management/src/App.vue
@@ -1,0 +1,8 @@
+<template>
+  <div class="p-4">
+    <h2 class="text-lg font-bold">Customer Management</h2>
+  </div>
+</template>
+
+<script setup lang="ts">
+</script>

--- a/packages/micro-apps/customer-management/src/main.ts
+++ b/packages/micro-apps/customer-management/src/main.ts
@@ -1,0 +1,6 @@
+import { createApp } from 'vue'
+import { createPinia } from 'pinia'
+import App from './App.vue'
+import '@enterprise/ui-kit/styles'
+
+createApp(App).use(createPinia()).mount('#app')

--- a/packages/micro-apps/customer-management/tailwind.config.js
+++ b/packages/micro-apps/customer-management/tailwind.config.js
@@ -1,0 +1,6 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: [ './index.html', './src/**/*.{vue,ts,tsx}' ],
+  theme: { extend: {} },
+  plugins: [],
+}

--- a/packages/micro-apps/customer-management/vite.config.ts
+++ b/packages/micro-apps/customer-management/vite.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from 'vite'
+import vue from '@vitejs/plugin-vue'
+import federation from '@originjs/vite-plugin-federation'
+
+export default defineConfig({
+  plugins: [
+    vue(),
+    federation({
+      name: 'customer',
+      filename: 'remoteEntry.js',
+      exposes: { './App': './src/App.vue' },
+      shared: ['vue', 'pinia', 'vue-router']
+    })
+  ],
+  server: { port: 5174 },
+  build: { target: 'esnext' }
+})

--- a/packages/micro-apps/insurance/index.html
+++ b/packages/micro-apps/insurance/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>MFE</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/packages/micro-apps/insurance/package.json
+++ b/packages/micro-apps/insurance/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@enterprise/insurance",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vue-tsc && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "vue": "^3.4.0",
+    "vue-router": "^4.2.0",
+    "pinia": "^2.1.0",
+    "@enterprise/ui-kit": "workspace:*",
+    "@enterprise/auth": "workspace:*",
+    "@enterprise/event-bus": "workspace:*"
+  },
+    "devDependencies": {
+    "@vitejs/plugin-vue": "^5.0.0",
+    "@originjs/vite-plugin-federation": "^1.3.0",
+    "vite": "^5.1.0",
+    "vue-tsc": "^1.8.0",
+    "sass": "^1.70.0",
+    "tailwindcss": "^3.4.0",
+    "autoprefixer": "^10.4.0",
+    "postcss": "^8.4.0"
+    }
+}

--- a/packages/micro-apps/insurance/postcss.config.js
+++ b/packages/micro-apps/insurance/postcss.config.js
@@ -1,0 +1,1 @@
+export default { plugins: { tailwindcss: {}, autoprefixer: {} } }

--- a/packages/micro-apps/insurance/src/App.vue
+++ b/packages/micro-apps/insurance/src/App.vue
@@ -1,0 +1,8 @@
+<template>
+  <div class="p-4">
+    <h2 class="text-lg font-bold">Insurance</h2>
+  </div>
+</template>
+
+<script setup lang="ts">
+</script>

--- a/packages/micro-apps/insurance/src/main.ts
+++ b/packages/micro-apps/insurance/src/main.ts
@@ -1,0 +1,6 @@
+import { createApp } from 'vue'
+import { createPinia } from 'pinia'
+import App from './App.vue'
+import '@enterprise/ui-kit/styles'
+
+createApp(App).use(createPinia()).mount('#app')

--- a/packages/micro-apps/insurance/tailwind.config.js
+++ b/packages/micro-apps/insurance/tailwind.config.js
@@ -1,0 +1,6 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: [ './index.html', './src/**/*.{vue,ts,tsx}' ],
+  theme: { extend: {} },
+  plugins: [],
+}

--- a/packages/micro-apps/insurance/vite.config.ts
+++ b/packages/micro-apps/insurance/vite.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from 'vite'
+import vue from '@vitejs/plugin-vue'
+import federation from '@originjs/vite-plugin-federation'
+
+export default defineConfig({
+  plugins: [
+    vue(),
+    federation({
+      name: 'insurance',
+      filename: 'remoteEntry.js',
+      exposes: { './App': './src/App.vue' },
+      shared: ['vue', 'pinia', 'vue-router']
+    })
+  ],
+  server: { port: 5175 },
+  build: { target: 'esnext' }
+})

--- a/packages/micro-apps/loan-management/index.html
+++ b/packages/micro-apps/loan-management/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>MFE</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/packages/micro-apps/loan-management/package.json
+++ b/packages/micro-apps/loan-management/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@enterprise/loan-management",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vue-tsc && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "vue": "^3.4.0",
+    "vue-router": "^4.2.0",
+    "pinia": "^2.1.0",
+    "@enterprise/ui-kit": "workspace:*",
+    "@enterprise/auth": "workspace:*",
+    "@enterprise/event-bus": "workspace:*"
+  },
+    "devDependencies": {
+    "@vitejs/plugin-vue": "^5.0.0",
+    "@originjs/vite-plugin-federation": "^1.3.0",
+    "vite": "^5.1.0",
+    "vue-tsc": "^1.8.0",
+    "sass": "^1.70.0",
+    "tailwindcss": "^3.4.0",
+    "autoprefixer": "^10.4.0",
+    "postcss": "^8.4.0"
+    }
+}

--- a/packages/micro-apps/loan-management/postcss.config.js
+++ b/packages/micro-apps/loan-management/postcss.config.js
@@ -1,0 +1,1 @@
+export default { plugins: { tailwindcss: {}, autoprefixer: {} } }

--- a/packages/micro-apps/loan-management/src/App.vue
+++ b/packages/micro-apps/loan-management/src/App.vue
@@ -1,0 +1,8 @@
+<template>
+  <div class="p-4">
+    <h2 class="text-lg font-bold">Loan Management</h2>
+  </div>
+</template>
+
+<script setup lang="ts">
+</script>

--- a/packages/micro-apps/loan-management/src/main.ts
+++ b/packages/micro-apps/loan-management/src/main.ts
@@ -1,0 +1,6 @@
+import { createApp } from 'vue'
+import { createPinia } from 'pinia'
+import App from './App.vue'
+import '@enterprise/ui-kit/styles'
+
+createApp(App).use(createPinia()).mount('#app')

--- a/packages/micro-apps/loan-management/tailwind.config.js
+++ b/packages/micro-apps/loan-management/tailwind.config.js
@@ -1,0 +1,6 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: [ './index.html', './src/**/*.{vue,ts,tsx}' ],
+  theme: { extend: {} },
+  plugins: [],
+}

--- a/packages/micro-apps/loan-management/vite.config.ts
+++ b/packages/micro-apps/loan-management/vite.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from 'vite'
+import vue from '@vitejs/plugin-vue'
+import federation from '@originjs/vite-plugin-federation'
+
+export default defineConfig({
+  plugins: [
+    vue(),
+    federation({
+      name: 'loan',
+      filename: 'remoteEntry.js',
+      exposes: { './App': './src/App.vue' },
+      shared: ['vue', 'pinia', 'vue-router']
+    })
+  ],
+  server: { port: 5176 },
+  build: { target: 'esnext' }
+})

--- a/packages/shell/index.html
+++ b/packages/shell/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Shell</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/packages/shell/package.json
+++ b/packages/shell/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@enterprise/shell",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vue-tsc && vite build",
+    "preview": "vite preview",
+    "type-check": "vue-tsc --noEmit",
+    "lint": "eslint . --ext .vue,.ts,.tsx --fix"
+  },
+  "dependencies": {
+    "vue": "^3.4.0",
+    "vue-router": "^4.2.0",
+    "pinia": "^2.1.0",
+    "@enterprise/ui-kit": "workspace:*",
+    "@enterprise/auth": "workspace:*",
+    "@enterprise/event-bus": "workspace:*",
+    "@enterprise/api-client": "workspace:*",
+    "@enterprise/shared-utils": "workspace:*",
+    "@enterprise/types": "workspace:*"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-vue": "^5.0.0",
+    "@originjs/vite-plugin-federation": "^1.3.0",
+    "vite": "^5.1.0",
+    "vue-tsc": "^1.8.0",
+    "sass": "^1.70.0",
+    "tailwindcss": "^3.4.0",
+    "autoprefixer": "^10.4.0",
+    "postcss": "^8.4.0"
+  }
+}

--- a/packages/shell/postcss.config.js
+++ b/packages/shell/postcss.config.js
@@ -1,0 +1,3 @@
+export default {
+  plugins: { tailwindcss: {}, autoprefixer: {} },
+}

--- a/packages/shell/src/App.vue
+++ b/packages/shell/src/App.vue
@@ -1,0 +1,7 @@
+<template>
+  <router-view />
+</template>
+
+<script setup lang="ts">
+// Root component
+</script>

--- a/packages/shell/src/assets/styles/main.css
+++ b/packages/shell/src/assets/styles/main.css
@@ -1,0 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+body {
+  font-family: var(--font-family, sans-serif);
+}

--- a/packages/shell/src/main.ts
+++ b/packages/shell/src/main.ts
@@ -1,0 +1,24 @@
+import { createApp } from 'vue'
+import { createPinia } from 'pinia'
+import { router } from './router'
+import { EventBusPlugin } from '@enterprise/event-bus'
+import App from './App.vue'
+import '@enterprise/ui-kit/styles'
+import './assets/styles/main.css'
+
+// Create app
+const app = createApp(App)
+
+// Install plugins
+app.use(createPinia())
+app.use(router)
+app.use(EventBusPlugin)
+
+// Global error handler
+app.config.errorHandler = (err, instance, info) => {
+  console.error('Global error:', err, info)
+  // Send to monitoring service
+}
+
+// Mount
+app.mount('#app')

--- a/packages/shell/src/router.ts
+++ b/packages/shell/src/router.ts
@@ -1,0 +1,12 @@
+import { createRouter, createWebHistory, RouteRecordRaw } from 'vue-router'
+import Home from './views/Home.vue'
+import MicroHost from './views/MicroHost.vue'
+
+const routes: RouteRecordRaw[] = [
+  { path: '/', component: Home },
+  { path: '/customer', component: MicroHost, props: { remoteSpec: 'customer/App' } },
+  { path: '/insurance', component: MicroHost, props: { remoteSpec: 'insurance/App' } },
+  { path: '/loan', component: MicroHost, props: { remoteSpec: 'loan/App' } },
+]
+
+export const router = createRouter({ history: createWebHistory(), routes })

--- a/packages/shell/src/views/Home.vue
+++ b/packages/shell/src/views/Home.vue
@@ -1,0 +1,22 @@
+<template>
+  <div class="p-4 space-y-4">
+    <h1 class="text-2xl font-bold">Enterprise Portal</h1>
+    <div class="flex gap-2">
+      <RouterLink to="/" class="underline">Home</RouterLink>
+      <RouterLink to="/customer" class="underline">Customer</RouterLink>
+      <RouterLink to="/insurance" class="underline">Insurance</RouterLink>
+      <RouterLink to="/loan" class="underline">Loan</RouterLink>
+    </div>
+    <component :is="ButtonTag" @click="count++">Clicked {{ count }} times</component>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+let ButtonTag: any = 'button'
+try {
+  const { BaseButton } = await import('@enterprise/ui-kit')
+  ButtonTag = BaseButton ?? 'button'
+} catch {}
+const count = ref(0)
+</script>

--- a/packages/shell/src/views/MicroHost.vue
+++ b/packages/shell/src/views/MicroHost.vue
@@ -1,0 +1,19 @@
+<template>
+  <div>
+    <component v-if="Remote" :is="Remote" />
+    <div v-else class="p-4">Loading remote...</div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+const props = defineProps<{ remoteSpec: string }>()
+const Remote = ref<any>(null)
+onMounted(async () => {
+  try {
+    const mod = await import(/* @vite-ignore */ props.remoteSpec)
+    // support default or named exports
+    Remote.value = (mod as any).default || (mod as any).App || mod
+  } catch (e) { console.error('Failed to load remote', props.remoteSpec, e) }
+})
+</script>

--- a/packages/shell/tailwind.config.js
+++ b/packages/shell/tailwind.config.js
@@ -1,0 +1,10 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: [
+    './index.html',
+    './src/**/*.{vue,ts,tsx}',
+    '../core/ui-kit/src/**/*.{vue,ts,tsx}'
+  ],
+  theme: { extend: {} },
+  plugins: [],
+}

--- a/packages/shell/vite.config.ts
+++ b/packages/shell/vite.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from 'vite'
+import vue from '@vitejs/plugin-vue'
+import federation from '@originjs/vite-plugin-federation'
+
+export default defineConfig({
+  plugins: [
+    vue(),
+    federation({
+      name: 'shell',
+      remotes: {
+        customer: 'http://localhost:5174/assets/remoteEntry.js',
+        insurance: 'http://localhost:5175/assets/remoteEntry.js',
+        loan: 'http://localhost:5176/assets/remoteEntry.js',
+      },
+      shared: ['vue', 'pinia', 'vue-router']
+    })
+  ],
+  server: { port: 5173 },
+  build: { target: 'esnext' }
+})

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,4 @@
+packages:
+  - 'packages/core/*'
+  - 'packages/shell'
+  - 'packages/micro-apps/*'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,32 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "jsx": "preserve",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "allowJs": false,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "isolatedModules": true,
+    "allowSyntheticDefaultImports": true,
+    "noEmit": true,
+    "types": ["vite/client", "node"],
+    "paths": {
+      "@enterprise/ui-kit": ["./packages/core/ui-kit/src"],
+      "@enterprise/auth": ["./packages/core/auth/src"],
+      "@enterprise/api-client": ["./packages/core/api-client/src"],
+      "@enterprise/event-bus": ["./packages/core/event-bus/src"],
+      "@enterprise/shared-utils": ["./packages/core/shared-utils/src"],
+      "@enterprise/types": ["./packages/core/types/src"]
+    }
+  },
+  "include": ["packages/**/*.ts", "packages/**/*.tsx", "packages/**/*.vue"],
+  "exclude": ["node_modules", "**/dist", "**/build"]
+}

--- a/turbo.json
+++ b/turbo.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "globalDependencies": ["**/.env.*local", "tsconfig.json"],
+  "pipeline": {
+    "build": {
+      "dependsOn": ["^build"],
+      "outputs": ["dist/**", ".next/**", "build/**"],
+      "cache": true
+    },
+    "dev": {
+      "cache": false,
+      "persistent": true,
+      "dependsOn": ["^build"]
+    },
+    "lint": {
+      "outputs": [],
+      "cache": true
+    },
+    "type-check": {
+      "dependsOn": ["^build"],
+      "cache": true
+    },
+    "clean": {
+      "cache": false
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- configure shell and micro-apps for Vite Module Federation with dedicated ports
- add Tailwind/PostCSS setup and module-federated router with dynamic remote loader
- remove test/CI scaffolding

## Testing
- `pnpm install` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.5.2.tgz)*
- `pnpm dev` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.5.2.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_68adfe9283088332852ff17d37f998c4